### PR TITLE
[No Merge] Winsock Picotron listener:accept() bug

### DIFF
--- a/src/http.lua
+++ b/src/http.lua
@@ -146,6 +146,20 @@ end
 
 function HTTPServer:Update()
 	if self.listener then
+		--[[
+
+		listener:accept() on windows "always" returns truthy
+		so self.clients builds up to ~510 sockets then stops accepting
+		new connections. Even Zep's example in the manual does not work
+		on windows
+
+		calling sock:close() does free up those socket connections
+		but I'm not entirely sure how that would best fit with the below
+		Windows (Unless Zep considers this a bug) needs to operate in a 
+		KeepAlive=false manner where the socket is immediately closed
+		after being read
+
+		]]--
 		local new_client = self.listener:accept()
 		if new_client then
 			add(self.clients, HTTPSocket:New(new_client))


### PR DESCRIPTION
Not sure how best to fix the issue, potentially if Zep is aware of the bug he can just fix the winsock handling; I don't really know how to make him aware of it. On second thought it wasn't worth making the implementation worse just because of a windows bug

On windows, I just don't track a list of clients. 

<img width="1200" height="862" alt="image" src="https://github.com/user-attachments/assets/63dca3e2-8761-46dc-a044-9ef7f95015e0" />
